### PR TITLE
Update .Rbuildignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,7 +9,6 @@
 ^node_modules$
 ^img$
 ^webpack\.config\.js$
-^inst/htmlwidgets/lib/.*$
 ^inst/htmlwidgets/dist/.*\.map$
 ^inst/testdata
 ^index\.md$


### PR DESCRIPTION
I think building R packages should not ignore this directory, which will cause it to be unusable in shiny